### PR TITLE
Minor CMake improvements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,11 @@ include_directories(${PGNP_INCLUDE_DIR})
 # ChessMoveInterface
 add_subdirectory(libs/chess-move-interface)
 include_directories(${CMI_INCLUDE_DIR})
+target_link_libraries(pgnp PRIVATE ChessMoveInterface)
+
+# Add include directiries to target to be independent of ${PGNP_INCLUDE_DIR} and ${CMI_INCLUDE_DIR}
+target_include_directories(pgnp PUBLIC ${CMI_INCLUDE_DIR})
+target_include_directories(pgnp PUBLIC ${PGNP_INCLUDE_DIR})
 
 # Unit tests
 set(COMPILE_TESTS OFF CACHE BOOL "Should unit tests be compiled")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@ include_directories(${PGNP_INCLUDE_DIR})
 # ChessMoveInterface
 add_subdirectory(libs/chess-move-interface)
 include_directories(${CMI_INCLUDE_DIR})
-target_link_libraries(pgnp PRIVATE ChessMoveInterface)
+target_link_libraries(pgnp PUBLIC ChessMoveInterface)
 
 # Add include directiries to target to be independent of ${PGNP_INCLUDE_DIR} and ${CMI_INCLUDE_DIR}
 target_include_directories(pgnp PUBLIC ${CMI_INCLUDE_DIR})


### PR DESCRIPTION
Hey! Nice lib. 

It might be super useful for my university project.
Unfortunately it wont compile on my m1 mac as is.

1. So I got linker error and added "target_link_libraries(pgnp PRIVATE ChessMoveInterface)" to get rid of it.

2. Also my project tree looks like:

root
-- CMakeLists.txt           #------ PGNP_INCLUDE_DIR and CMI_INCLUDE_DIR are NOT visible anymore
-- 3rdparty
---- CMakeLists.txt       #---- PGNP_INCLUDE_DIR and CMI_INCLUDE_DIR are visible
---- pgnp
------ CMakeLists.txt    #-- PGNP_INCLUDE_DIR and CMI_INCLUDE_DIR are defined

So it would be easier to me to add this alternative to original solution for access to include directories.
target_include_directories(pgnp PUBLIC ${CMI_INCLUDE_DIR})
target_include_directories(pgnp PUBLIC ${PGNP_INCLUDE_DIR}) 

What do you think? Maybe i miss some CMake magic and it should be just fine?
